### PR TITLE
Fixed the hanging in v2.0

### DIFF
--- a/src/workflow/workflow3.py
+++ b/src/workflow/workflow3.py
@@ -443,3 +443,4 @@ class Workflow3(Workflow):
         """Print stored items to console/Alfred as JSON."""
         json.dump(self.obj, sys.stdout)
         sys.stdout.flush()
+        sys.exit()


### PR DESCRIPTION
Downloaded v2.0.0 this morning, and it was still hanging when running `pwlen`. Running the script directly in the Terminal showed that even though the JSON was being sent to the output buffer, the script had not completed running. Hence, the workflow would _hang_.

I patched my local copy by adding this line to explicitly end the script.

----

* Running Alfred 3.3.1 [805] (Prerelease)
* Running macOS 10.12.4β
* `/usr/bin/python` is Python 2.7.10.