### PR TITLE
Fix paste when using cmd-return

### DIFF
--- a/src/pwgen.py
+++ b/src/pwgen.py
@@ -327,8 +327,11 @@ class PasswordApp(object):
             it.setvar('notification', 'Password copied to clipboard')
             it.setvar('action', 'copy')
 
-            m = it.add_modifier('cmd',
-                'Copy to clipboard and paste to frontmost application')
+            m = it.add_modifier(
+                'cmd',
+                subtitle='Copy to clipboard and paste to frontmost application',
+                arg=pw,
+                valid=True)
             m.setvar('action', 'paste')
 
         wf.send_feedback()


### PR DESCRIPTION
Cmd-return to copy and paste a password wasn't working for me.  I think hitting cmd-return was correctly setting action=paste, but it wasn't passing along the password in arg, which resulted in nothing being copied to the clipboard nor pasted when using the modifier.

I am not sure whether this fix is proper here, or whether instead the workflow library should automatically copy the item's arg to a modifier when it is not given, just as it does with variables.  Luckily I think you're familiar with the maintainer of that upstream library. ;)

I also added `valid=True` to the modifier while I was here, to mirror the `valid=True` in the preceding wf.add_item, though it doesn't seem to be required by Alfred.

Thanks for this useful workflow!